### PR TITLE
Feature/#18 login impl

### DIFF
--- a/app/src/main/java/com/apptive/easywine/EasyWineApp.kt
+++ b/app/src/main/java/com/apptive/easywine/EasyWineApp.kt
@@ -19,7 +19,7 @@ fun EasyWineApp() {
 			var navController = rememberNavController()
 			NavHost(
 				navController = navController,
-				startDestination = Screen.HomeScreen.route
+				startDestination = Screen.LoginScreen.route,
 			) {
 				easyWineGraph(
 					navController = navController

--- a/app/src/main/java/com/apptive/easywine/EasyWineApplication.kt
+++ b/app/src/main/java/com/apptive/easywine/EasyWineApplication.kt
@@ -1,7 +1,24 @@
 package com.apptive.easywine
 
 import android.app.Application
+import android.content.Context
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
-class EasyWineApplication : Application()
+class EasyWineApplication : Application() {
+
+	init{
+		instance = this
+	}
+
+	companion object {
+		lateinit var instance: EasyWineApplication
+		fun applicationContext() : Context {
+			return instance.applicationContext
+		}
+	}
+
+	override fun onCreate() {
+		super.onCreate()
+	}
+}

--- a/app/src/main/java/com/apptive/easywine/data/remote/MemberApi.kt
+++ b/app/src/main/java/com/apptive/easywine/data/remote/MemberApi.kt
@@ -1,0 +1,23 @@
+package com.apptive.easywine.data.remote
+
+import com.apptive.easywine.domain.model.EmailPassword
+import com.apptive.easywine.domain.model.LoginInfo
+import com.apptive.easywine.domain.model.Question
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.POST
+
+interface MemberApi {
+
+//	@POST("/member/join/v1")
+//	suspend fun join(
+//	): Response<>
+
+	@POST("member/login/v1")
+	suspend fun doLogin(
+		@Body emailPassword: EmailPassword
+	): Response<LoginInfo>
+
+}

--- a/app/src/main/java/com/apptive/easywine/data/repository/MemberRepositoryImpl.kt
+++ b/app/src/main/java/com/apptive/easywine/data/repository/MemberRepositoryImpl.kt
@@ -1,0 +1,19 @@
+package com.apptive.easywine.data.repository
+
+import com.apptive.easywine.data.remote.MemberApi
+import com.apptive.easywine.data.remote.SurveyApi
+import com.apptive.easywine.domain.model.EmailPassword
+import com.apptive.easywine.domain.model.LoginInfo
+import com.apptive.easywine.domain.model.Question
+import com.apptive.easywine.domain.repository.MemberRepository
+import com.apptive.easywine.domain.repository.SurveyRepository
+import retrofit2.Response
+import javax.inject.Inject
+
+class MemberRepositoryImpl @Inject constructor(
+	private val api: MemberApi
+): MemberRepository {
+	override suspend fun doLogin(emailPassword: EmailPassword): Response<LoginInfo> {
+		return api.doLogin(emailPassword)
+	}
+}

--- a/app/src/main/java/com/apptive/easywine/di/NetworkModule.kt
+++ b/app/src/main/java/com/apptive/easywine/di/NetworkModule.kt
@@ -2,8 +2,11 @@ package com.apptive.easywine.di
 
 import android.util.Log
 import com.apptive.easywine._const.NetworkConst.BASE_URL
+import com.apptive.easywine.data.remote.MemberApi
 import com.apptive.easywine.data.remote.SurveyApi
+import com.apptive.easywine.data.repository.MemberRepositoryImpl
 import com.apptive.easywine.data.repository.SurveyRepositoryImpl
+import com.apptive.easywine.domain.repository.MemberRepository
 import com.apptive.easywine.domain.repository.SurveyRepository
 import dagger.Module
 import dagger.Provides
@@ -82,6 +85,19 @@ object NetworkModule {
 	@Singleton
 	fun provideSurveyRepository(api: SurveyApi): SurveyRepository {
 		return SurveyRepositoryImpl(api)
+	}
+
+
+	@Provides
+	@Singleton
+	fun provideMemberApi(retrofit: Retrofit): MemberApi {
+		return retrofit.create(MemberApi::class.java)
+	}
+
+	@Provides
+	@Singleton
+	fun provideMemberRepository(api: MemberApi): MemberRepository {
+		return MemberRepositoryImpl(api)
 	}
 
 }

--- a/app/src/main/java/com/apptive/easywine/domain/model/EmailPassword.kt
+++ b/app/src/main/java/com/apptive/easywine/domain/model/EmailPassword.kt
@@ -1,0 +1,6 @@
+package com.apptive.easywine.domain.model
+
+data class EmailPassword(
+	val email:String = "",
+	val pass:String = "",
+)

--- a/app/src/main/java/com/apptive/easywine/domain/model/LoginInfo.kt
+++ b/app/src/main/java/com/apptive/easywine/domain/model/LoginInfo.kt
@@ -1,0 +1,10 @@
+package com.apptive.easywine.domain.model
+
+data class LoginInfo(
+	var email : String = "",
+	var pass : String = "",
+	var token : String = "",
+	var name : String = "",
+	var gender : Int = 0,
+	var age : Int = 0,
+)

--- a/app/src/main/java/com/apptive/easywine/domain/repository/MemberRepository.kt
+++ b/app/src/main/java/com/apptive/easywine/domain/repository/MemberRepository.kt
@@ -1,0 +1,10 @@
+package com.apptive.easywine.domain.repository
+
+import com.apptive.easywine.domain.model.EmailPassword
+import com.apptive.easywine.domain.model.LoginInfo
+import com.apptive.easywine.domain.model.Question
+import retrofit2.Response
+
+interface MemberRepository {
+	suspend fun doLogin(emailPassword: EmailPassword): Response<LoginInfo>
+}

--- a/app/src/main/java/com/apptive/easywine/domain/use_case/member/doLogin.kt
+++ b/app/src/main/java/com/apptive/easywine/domain/use_case/member/doLogin.kt
@@ -1,0 +1,36 @@
+package com.apptive.easywine.domain.use_case.member
+
+import android.util.Log
+import com.apptive.easywine.domain.model.EmailPassword
+import com.apptive.easywine.domain.model.LoginInfo
+import com.apptive.easywine.domain.repository.MemberRepository
+import com.apptive.easywine.domain.util.Resource
+import com.apptive.easywine.domain.util.log
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import retrofit2.HttpException
+import java.io.IOException
+import javax.inject.Inject
+
+
+class doLogin @Inject constructor(
+    val repository: MemberRepository
+){
+    operator fun invoke(emailPassword: EmailPassword): Flow<Resource<LoginInfo>> = flow {
+        try {
+            emit(Resource.Loading())
+            val r = repository.doLogin(emailPassword)
+
+            when(r.code()) {
+                200 -> emit(Resource.Success(r.body()!!))
+                else -> Log.d("use case", r.errorBody().toString())
+            }
+        } catch(e: HttpException) {
+            "An unexpected error occured".log("use case")
+            emit(Resource.Error(e.localizedMessage ?: "An unexpected error occured"))
+        } catch(e: IOException) {
+            "Couldn't reach server. Check your internet connection".log("use case")
+            emit(Resource.Error("Couldn't reach server. Check your internet connection."))
+        }
+    }
+}

--- a/app/src/main/java/com/apptive/easywine/presentation/Login/Login.kt
+++ b/app/src/main/java/com/apptive/easywine/presentation/Login/Login.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Button
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
-import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment

--- a/app/src/main/java/com/apptive/easywine/presentation/Login/Login.kt
+++ b/app/src/main/java/com/apptive/easywine/presentation/Login/Login.kt
@@ -1,0 +1,74 @@
+package com.apptive.easywine.presentation.Login
+
+import android.widget.Toast
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.Button
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import com.apptive.easywine.domain.util.log
+import com.apptive.easywine.presentation.navgation.Screen
+import kotlinx.coroutines.flow.collectLatest
+
+@Composable
+fun LoginScreen(
+	navController: NavController,
+	viewModel: LoginViewModel = hiltViewModel()
+) {
+	val context = LocalContext.current
+
+	LaunchedEffect(key1 = true) {
+		viewModel.eventFlow.collectLatest { event ->
+			when(event) {
+				is LoginViewModel.UiEvent.Error -> {
+					"LOGIN ERROR!!".log()
+					Toast.makeText(context, "LOGIN ERROR!!", Toast.LENGTH_SHORT).show()
+				}
+				is LoginViewModel.UiEvent.Login -> {
+					"LOGIN SUCCESS!!".log()
+					Toast.makeText(context, "LOGIN SUCCESS!!", Toast.LENGTH_SHORT).show()
+					navController.navigate(Screen.HomeScreen.route) {
+						popUpTo(0)
+					}
+				}
+			}
+		}
+	}
+
+	Column(
+		verticalArrangement = Arrangement.Center,
+		horizontalAlignment = Alignment.CenterHorizontally,
+		modifier = Modifier.fillMaxSize()
+	) {
+		OutlinedTextField(value = viewModel.emailPw.value.email,
+			onValueChange = { viewModel.onEvent(LoginEvent.EnteredEmail(it)) },
+			keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email)
+		)
+		OutlinedTextField(value = viewModel.emailPw.value.pass,
+			onValueChange = { viewModel.onEvent(LoginEvent.EnteredPassword(it)) },
+			keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password)
+		)
+		Spacer(modifier = Modifier.size(150.dp))
+		Button(onClick = { viewModel.onEvent(LoginEvent.Login) }) {
+			Text("로그인")
+		}
+	}
+}
+
+@Preview
+@Composable
+fun PreviewLoginScreen() {
+	LoginScreen(rememberNavController())
+}

--- a/app/src/main/java/com/apptive/easywine/presentation/Login/LoginEvent.kt
+++ b/app/src/main/java/com/apptive/easywine/presentation/Login/LoginEvent.kt
@@ -1,0 +1,7 @@
+package com.apptive.easywine.presentation.Login
+
+sealed class LoginEvent {
+    data class EnteredEmail(val value: String): LoginEvent()
+    data class EnteredPassword(val value: String): LoginEvent()
+    object Login: LoginEvent()
+}

--- a/app/src/main/java/com/apptive/easywine/presentation/Login/LoginViewModel.kt
+++ b/app/src/main/java/com/apptive/easywine/presentation/Login/LoginViewModel.kt
@@ -1,0 +1,92 @@
+package com.apptive.easywine.presentation.Login
+
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.apptive.easywine.domain.model.EmailPassword
+import com.apptive.easywine.domain.util.log
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class LoginViewModel @Inject constructor(
+//	loginUseCases: LoginUseCases
+): ViewModel() {
+	private var _emailPw = mutableStateOf(
+		EmailPassword(
+			// TODO: delete later
+			email = "test1",
+			pass = "test1",
+		)
+	)
+	val emailPw: State<EmailPassword> = _emailPw
+
+	private val _eventFlow = MutableSharedFlow<UiEvent>()
+	val eventFlow = _eventFlow.asSharedFlow()
+
+	/*
+	private suspend fun login() {
+		loginUseCases.doLogin(_emailPw.value).collectLatest {
+			when (it) {
+				is Resource.Success -> {
+					_eventFlow.emit(UiEvent.Login)
+				}
+				is Resource.Error -> {
+					"로그인 중 에러 발생".log()
+					_eventFlow.emit(UiEvent.Error("cannot login"))
+				}
+				is Resource.Loading -> {
+					"토큰 값 가져오는 중...".log()
+				}
+			}
+		}
+	}
+	 */
+
+	private suspend fun login() {
+		_eventFlow.emit(UiEvent.Login)
+		//_eventFlow.emit(UiEvent.Error("cannot login"))
+	}
+
+	fun onEvent(event: LoginEvent) {
+		when (event) {
+			is LoginEvent.EnteredEmail -> {
+				_emailPw.value = emailPw.value.copy(
+					email = event.value
+				)
+			}
+			is LoginEvent.EnteredPassword -> {
+				_emailPw.value = emailPw.value.copy(
+					pass = event.value
+				)
+			}
+			is LoginEvent.Login -> {
+				viewModelScope.launch {
+					try {
+						if (emailPw.value.email.isNullOrBlank()
+							|| emailPw.value.pass.isNullOrBlank()
+						) {
+							"ERROR 입력 되지 않은 칸이 존재".log()
+							_eventFlow.emit(UiEvent.Error(message = "모든 칸의 내용을 채워주세요"))
+							return@launch
+						}
+						 login()
+					} catch (e: Exception) {
+						"로그인 중 에러 발생".log()
+						_eventFlow.emit(UiEvent.Error(message = "로그인 중 에러 발생"))
+					}
+				}
+			}
+		}
+
+	}
+
+	sealed class UiEvent {
+		data class Error(val message: String) : UiEvent()
+		object Login : UiEvent()
+	}
+}

--- a/app/src/main/java/com/apptive/easywine/presentation/Login/LoginViewModel.kt
+++ b/app/src/main/java/com/apptive/easywine/presentation/Login/LoginViewModel.kt
@@ -5,22 +5,25 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.apptive.easywine.domain.model.EmailPassword
+import com.apptive.easywine.domain.use_case.member.doLogin
+import com.apptive.easywine.domain.util.Resource
 import com.apptive.easywine.domain.util.log
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class LoginViewModel @Inject constructor(
-//	loginUseCases: LoginUseCases
+	private val doLoginUseCase: doLogin
 ): ViewModel() {
 	private var _emailPw = mutableStateOf(
 		EmailPassword(
 			// TODO: delete later
 			email = "test1",
-			pass = "test1",
+			pass = "1234",
 		)
 	)
 	val emailPw: State<EmailPassword> = _emailPw
@@ -28,9 +31,8 @@ class LoginViewModel @Inject constructor(
 	private val _eventFlow = MutableSharedFlow<UiEvent>()
 	val eventFlow = _eventFlow.asSharedFlow()
 
-	/*
 	private suspend fun login() {
-		loginUseCases.doLogin(_emailPw.value).collectLatest {
+		doLoginUseCase(_emailPw.value).collectLatest {
 			when (it) {
 				is Resource.Success -> {
 					_eventFlow.emit(UiEvent.Login)
@@ -44,12 +46,6 @@ class LoginViewModel @Inject constructor(
 				}
 			}
 		}
-	}
-	 */
-
-	private suspend fun login() {
-		_eventFlow.emit(UiEvent.Login)
-		//_eventFlow.emit(UiEvent.Error("cannot login"))
 	}
 
 	fun onEvent(event: LoginEvent) {

--- a/app/src/main/java/com/apptive/easywine/presentation/navigation/NavGraph.kt
+++ b/app/src/main/java/com/apptive/easywine/presentation/navigation/NavGraph.kt
@@ -4,6 +4,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.apptive.easywine.presentation.Home.HomeScreen
+import com.apptive.easywine.presentation.Login.LoginScreen
 import com.apptive.easywine.presentation.Survey.SurveyScreen
 
 fun NavGraphBuilder.easyWineGraph(
@@ -12,6 +13,10 @@ fun NavGraphBuilder.easyWineGraph(
 ) {
 	composable(Screen.SplashScreen.route) {
 		// Splash Screen
+	}
+
+	composable(Screen.LoginScreen.route) {
+		LoginScreen(navController)
 	}
 
 	composable(Screen.HomeScreen.route) {


### PR DESCRIPTION
# 변경점 👍
- 로그인 뷰를 만들었습니다 (대충 만들어서 디자인 나오면 수정 필요)
- 로그인 뷰 로직을 구현 했습니다. (상태관리, api 요청 등)
- 로그인 api (doLogin)을 구현했습니다. (member api, member repository 등 생성)
- 로그인 api usecase로 분리 했습니다.
 - 이제 로그인이 가능합니다.

 
# 스크린샷 🖼
![화면 기록 2022-11-27 오전 11 07 14](https://user-images.githubusercontent.com/46425142/204116151-83e4c1c6-73ba-4249-b71e-3fa692f02e72.gif)

 
# 비고 ✏
- 로그인 이벤트 처리에 reactive 프로그래밍은 적용했습니다. sharedFlow를 이용하여 이벤트를 발행하게 됩니다. [참고](https://www.kodeco.com/22030171-reactive-streams-on-kotlin-sharedflow-and-stateflow)
- LaunchedEffect를 사용하여 홈화면으로 넘어갑니다. 그 viewModel에서 이벤트를 발행합니다.
- 받은 토큰을 저장해야하는데 아직 구현하지 않았습니다.

close #18 
 